### PR TITLE
fix default arn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ install:
 cache: pip
 
 script:
-- black local_data_api tests --check --skip-string-normalization
-- mypy --ignore-missing-imports --disallow-untyped-defs local_data_api
-- isort --recursive --check-only -w 88 --combine-as --thirdparty local_data_api local_data_api tests -m 3 -tc
-- pytest --cov=local_data_api tests
+-  ./scripts/test.sh
+-  ./scripts/lint.sh
 - cp README.md docs/index.md && mkdocs build --verbose --clean --strict
 after_success:
 - codecov

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ The API converts RESTful request to SQL statements.
 you set your MYSQL Server configs as environments.
 
 ```bash
-docker run --rm -it --name my-data-api -p 8080:80  -e MYSQL_HOST=YOUR_MYSQL_HOST -e MYSQL_PORT=3306 -e MYSQL_USER=root -e MYSQL_PASSWORD=example -e RESOURCE_ARN=dummy -e SECRET_ARN=dummy  koxudaxi/local-data-api
+docker run --rm -it --name my-data-api -p 8080:80  -e MYSQL_HOST=127.0.0.1 -e MYSQL_PORT=3306 -e MYSQL_USER=root -e MYSQL_PASSWORD=example -e RESOURCE_ARN=arn:aws:rds:us-east-1:123456789012:cluster:dummy -e SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy  koxudaxi/local-data-api
 ```
 In this case, you give local-data-api URL to aws client (like aws-cli).
 ```bash
-$ aws --endpoint-url http://127.0.0.1:8080 rds-data execute-statement --resource-arn "dummy" --sql "show databases"  --secret-arn "dummy" --database 'test'
+$ aws --endpoint-url http://127.0.0.1:8080 rds-data execute-statement --resource-arn "arn:aws:rds:us-east-1:123456789012:cluster:dummy" --sql "show databases"  --secret-arn "arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy" --database 'test'
 ```
 
 ### Example: docker-compose with Python's aws-sdk client(boto3) 
@@ -40,8 +40,9 @@ services:
       MYSQL_PORT: 3306
       MYSQL_USER: root
       MYSQL_PASSWORD: example
-      RESOURCE_ARN: dummy
-      SECRET_ARN: dummy
+      MYSQL_JDBC_JAR_PATH: /usr/lib/jvm/mariadb-java-client.jar
+      RESOURCE_ARN: 'arn:aws:rds:us-east-1:123456789012:cluster:dummy'
+      SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy'
     ports:
       - "8080:80"
   db:
@@ -70,7 +71,7 @@ In [1]: import boto3; client = boto3.client('rds-data', endpoint_url='http://127
 
 3. execute a sql statement
 ```python
-In [2]: client.execute_statement(resourceArn='dummy', secretArn='dummy', sql='show databases', database='test')
+In [2]: client.execute_statement(resourceArn='arn:aws:rds:us-east-1:123456789012:cluster:dummy', secretArn='arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy', sql='show databases', database='test')
 ```
 
 4. local-data-api return the result from a MySQL Server.
@@ -91,7 +92,7 @@ Out[2]: {'ResponseMetadata': {'HTTPStatusCode': 200,
 
 If a table has some records, then the local-data-api cant run `select`
 ```python
-In [3]: client.execute_statement(resourceArn='dummy', secretArn='dummy', sql='select * from users', database='test')
+In [3]: client.execute_statement(resourceArn='arn:aws:rds:us-east-1:123456789012:cluster:dummy', secretArn='arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy', sql='select * from users', database='test')
 ```
 ```python
 Out[3]: {'ResponseMetadata': {'HTTPStatusCode': 200,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       MYSQL_USER: root
       MYSQL_PASSWORD: example
       MYSQL_JDBC_JAR_PATH: /usr/lib/jvm/mariadb-java-client.jar
-      RESOURCE_ARN: dummy
-      SECRET_ARN: dummy
+      RESOURCE_ARN: 'arn:aws:rds:us-east-1:123456789012:cluster:dummy'
+      SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy'
     ports:
       - "8080:80"
   db:

--- a/local_data_api/settings.py
+++ b/local_data_api/settings.py
@@ -5,8 +5,12 @@ import os
 from local_data_api.resources.resource import register_resource
 from local_data_api.secret_manager import register_secret
 
-RESOURCE_ARN: str = os.environ.get('RESOURCE_ARN', 'dummy')
-SECRET_ARN: str = os.environ.get('SECRET_ARN', 'dummy')
+RESOURCE_ARN: str = os.environ.get(
+    'RESOURCE_ARN', 'arn:aws:rds:us-east-1:123456789012:cluster:dummy'
+)
+SECRET_ARN: str = os.environ.get(
+    'SECRET_ARN', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy'
+)
 
 MYSQL_HOST: str = os.environ.get('MYSQL_HOST', '127.0.0.1')
 ENGINE: str = os.environ.get('ENGINE', 'MySQLJDBC')

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+black local_data_api tests --skip-string-normalization
+isort --recursive -w 88  --combine-as --thirdparty local_data_api local_data_api tests -m 3 -tc

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+black local_data_api tests --check --skip-string-normalization
+isort --recursive --check-only -w 88  --combine-as --thirdparty local_data_api local_data_api tests -m 3 -tc
+mypy local_data_api --disallow-untyped-defs --ignore-missing-imports

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+pytest --cov=local_data_api tests

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,9 +5,11 @@ def test_setup(mocker) -> None:
     mock_register_secret = mocker.patch('local_data_api.settings.register_secret')
     mock_register_resource = mocker.patch('local_data_api.settings.register_resource')
     setup()
-    mock_register_secret.assert_called_with('root', 'example', 'dummy')
+    mock_register_secret.assert_called_with(
+        'root', 'example', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy'
+    )
     mock_register_resource.assert_called_with(
-        'dummy',
+        'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
         'MySQLJDBC',
         '127.0.0.1',
         3306,


### PR DESCRIPTION
aws adds validation for ARN min length on boto3.
The PR fixes default ARNs and examples.