### PR TITLE
Support UUID field

### DIFF
--- a/local_data_api/main.py
+++ b/local_data_api/main.py
@@ -54,7 +54,7 @@ def commit_transaction(request: CommitTransactionRequest) -> CommitTransactionRe
 
 @app.post("/RollbackTransaction", response_model=RollbackTransactionResponse)
 def rollback_transaction(
-    request: RollbackTransactionRequest
+    request: RollbackTransactionRequest,
 ) -> RollbackTransactionResponse:
     resource: Resource = get_resource(
         request.resourceArn, request.secretArn, request.transactionId
@@ -108,7 +108,7 @@ def execute_statement(request: ExecuteStatementRequests) -> ExecuteStatementResp
     response_model_skip_defaults=True,
 )
 def batch_execute_statement(
-    request: BatchExecuteStatementRequests
+    request: BatchExecuteStatementRequests,
 ) -> BatchExecuteStatementResponse:
     resource: Optional[Resource] = None
     try:

--- a/local_data_api/models.py
+++ b/local_data_api/models.py
@@ -29,6 +29,8 @@ class Field(BaseModel):
             return cls(blobValue=b64encode(value))
         elif value is None:
             return cls(isNull=True)
+        elif type(value).__name__.endswith('UUID'):
+            return cls(stringValue=str(value))
         else:
             raise Exception(f'unsupported type {type(value)}: {value} ')
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-pytest --cov=local_data_api tests
+pytest --cov=local_data_api --cov-report term-missing tests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,16 @@ def test_from_value() -> None:
     assert Field.from_value(b'bytes') == Field(blobValue=b64encode(b'bytes'))
     assert Field.from_value(None) == Field(isNull=True)
 
+    class JavaUUID:
+        def __init__(self, val: str):
+            self._val: str = val
+
+        def __str__(self) -> str:
+            return self._val
+
+    uuid = 'e9e1df6b-c6d3-4a34-9227-c27056d596c6'
+    assert Field.from_value(JavaUUID(uuid)) == Field(stringValue=uuid)
+
     class Dummy:
         pass
 


### PR DESCRIPTION
Using a UUID field in postgres results in a `local-data-api` error:

`Exception: unsupported type <class 'jpype._jclass.java.util.UUID'>: cd7c97f0-6a4f-481d-8c4e-57effeb57778`

This PR matches the type name `UUID` and returns a string value, similarly how Data API does it. I was able to use this fix with our application. 

Also added the `--cov-report term-missing` flag to pytest, so the not covered lines are visible in the coverage report.