### PR TITLE
Support typeHint

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
+import datetime
 from base64 import b64encode
+from decimal import Decimal
 
 import pytest
 from local_data_api.models import Field, SqlParameter
@@ -12,6 +14,20 @@ def test_valid_field() -> None:
     assert SqlParameter(name='abc', value=Field(longValue=123)).valid_value == 123
     assert SqlParameter(name='abc', value=Field(longValue=123)).valid_value == 123
     assert SqlParameter(name='abc', value=Field()).valid_value is None
+    assert SqlParameter(
+        name='abc', value=Field(stringValue='123456789'), typeHint='DECIMAL'
+    ).valid_value == Decimal(123456789)
+    assert SqlParameter(
+        name='abc',
+        value=Field(stringValue='2020-02-27 00:30:15.290'),
+        typeHint='TIMESTAMP',
+    ).valid_value == datetime.datetime(2020, 2, 27, 0, 30, 15, 290000)
+    assert SqlParameter(
+        name='abc', value=Field(stringValue='00:30:15.290'), typeHint='TIME'
+    ).valid_value == datetime.time(0, 30, 15, 290000)
+    assert SqlParameter(
+        name='abc', value=Field(stringValue='2020-02-27'), typeHint='DATE'
+    ).valid_value == datetime.date(2020, 2, 27)
 
 
 def test_from_value() -> None:


### PR DESCRIPTION
This PR supports `typeHint`
https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html#rdsdtataservice-Type-SqlParameter-typeHint
