### PR TITLE
Completed support for PostgresSQL without JDBC

### DIFF
--- a/local_data_api/models.py
+++ b/local_data_api/models.py
@@ -31,6 +31,8 @@ class Field(BaseModel):
             return cls(booleanValue=value)
         elif isinstance(value, str):
             return cls(stringValue=value)
+        elif isinstance(value, datetime):
+            return cls(stringValue=str(value))
         elif isinstance(value, int):
             return cls(longValue=value)
         elif isinstance(value, float):

--- a/local_data_api/resources/postgres.py
+++ b/local_data_api/resources/postgres.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import psycopg2
+from psycopg2._psycopg import Column
 from sqlalchemy.dialects import postgresql
 
 from local_data_api.models import ColumnMetadata
@@ -12,12 +13,31 @@ if TYPE_CHECKING:  # pragma: no cover
     from local_data_api.resources.resource import ConnectionMaker, Cursor
 
 
+def create_column_metadata(field_descriptor_packet: Column) -> ColumnMetadata:
+    return ColumnMetadata(
+        arrayBaseColumnType=0,
+        isAutoIncrement=False,
+        isCaseSensitive=False,
+        isCurrency=False,
+        isSigned=False,
+        label=field_descriptor_packet.name,
+        name=field_descriptor_packet.name,
+        nullable=None,
+        precision=None,  # TODO: Implement
+        scale=field_descriptor_packet.scale,
+        schema=None,
+        tableName=field_descriptor_packet.name,
+        type=None,  # JDBC Type unsupported
+        typeName=None,  # JDBC TypeName unsupported
+    )
+
+
 @register_resource_type
 class PostgresSQL(Resource):
     def create_column_metadata_set(
         self, cursor: Cursor
     ) -> List[ColumnMetadata]:  # pragma: no cover
-        raise NotImplementedError
+        return [create_column_metadata(f) for f in getattr(cursor, 'description')]
 
     DIALECT = postgresql.dialect(paramstyle='named')
 

--- a/local_data_api/settings.py
+++ b/local_data_api/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -20,13 +21,13 @@ class DBSetting(BaseModel):
     PORT: int
     USER: str
     PASSWORD: str
-    JAR_PATH: str
+    JAR_PATH: Optional[str]
 
 
 def setup() -> None:
     # TODO: implement to create custom resource
     engine: str = os.environ.get('ENGINE', 'MySQLJDBC')
-    if engine.upper().startswith('MYSQL'):
+    if engine == 'MySQLJDBC':
         db_setting: DBSetting = DBSetting(
             HOST=os.environ.get('MYSQL_HOST', '127.0.0.1'),
             PORT=os.environ.get('MYSQL_PORT', '3306'),
@@ -36,7 +37,7 @@ def setup() -> None:
                 'MYSQL_JDBC_JAR_PATH', '/usr/lib/jvm/mariadb-java-client.jar'
             ),
         )
-    else:
+    elif engine == 'PostgreSQLJDBC':
         db_setting = DBSetting(
             HOST=os.environ.get('POSTGRES_HOST', '127.0.0.1'),
             PORT=os.environ.get('POSTGRES_PORT', '5432'),
@@ -46,6 +47,15 @@ def setup() -> None:
                 'POSTGRES_JDBC_JAR_PATH', '/usr/lib/jvm/postgresql-java-client.jar'
             ),
         )
+    elif engine == 'PostgresSQL':
+        db_setting = DBSetting(
+            HOST=os.environ.get('POSTGRES_HOST', '127.0.0.1'),
+            PORT=os.environ.get('POSTGRES_PORT', '5432'),
+            USER=os.environ.get('POSTGRES_USER', 'postgres'),
+            PASSWORD=os.environ.get('POSTGRES_PASSWORD', 'example'),
+        )
+    else:
+        raise NotImplementedError("Engine not already implemented")
 
     register_secret(db_setting.USER, db_setting.PASSWORD, SECRET_ARN)
     register_resource(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,9 @@ def test_from_value() -> None:
     assert Field.from_value(False) == Field(booleanValue=False)
     assert Field.from_value(b'bytes') == Field(blobValue=b64encode(b'bytes'))
     assert Field.from_value(None) == Field(isNull=True)
-    assert Field.from_value(datetime(2019, 5, 18, 15, 17, 8)) == Field(stringValue='2019-05-18 15:17:08')
+    assert Field.from_value(datetime(2019, 5, 18, 15, 17, 8)) == Field(
+        stringValue='2019-05-18 15:17:08'
+    )
 
     class JavaUUID:
         def __init__(self, val: str):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import datetime
 from base64 import b64encode
-from decimal import Decimal
+from datetime import datetime
 
 import pytest
 
@@ -15,6 +15,7 @@ def test_valid_field() -> None:
     assert SqlParameter(name='abc', value=Field(longValue=123)).valid_value == 123
     assert SqlParameter(name='abc', value=Field(longValue=123)).valid_value == 123
     assert SqlParameter(name='abc', value=Field()).valid_value is None
+
     assert (
         SqlParameter(
             name='abc', value=Field(stringValue='123456789'), typeHint='DECIMAL'
@@ -51,6 +52,7 @@ def test_from_value() -> None:
     assert Field.from_value(False) == Field(booleanValue=False)
     assert Field.from_value(b'bytes') == Field(blobValue=b64encode(b'bytes'))
     assert Field.from_value(None) == Field(isNull=True)
+    assert Field.from_value(datetime(2019, 5, 18, 15, 17, 8)) == Field(stringValue='2019-05-18 15:17:08')
 
     class JavaUUID:
         def __init__(self, val: str):

--- a/tests/test_resource/test_postgres.py
+++ b/tests/test_resource/test_postgres.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from psycopg2._psycopg import Column
+
 from local_data_api.resources import PostgresSQL
 
 
@@ -26,3 +28,15 @@ def test_create_connection_maker(mocker):
     connection_maker = PostgresSQL.create_connection_maker()
     connection_maker()
     mock_connect.assert_called_once_with()
+
+
+def test_create_column_metadata(mocker):
+    connection_mock = mocker.Mock()
+    cursor_mock = mocker.Mock()
+
+    connection_mock.cursor.side_effect = [cursor_mock]
+
+    cursor_mock.description = [Column(name="mock", scale=1)]
+    dummy = PostgresSQL(connection_mock)
+    dummy.create_column_metadata_set(cursor_mock)
+    assert True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,9 @@ from local_data_api.settings import setup
 def test_setup_mysql(mocker) -> None:
     mock_register_secret = mocker.patch('local_data_api.settings.register_secret')
     mock_register_resource = mocker.patch('local_data_api.settings.register_resource')
+    import os
+
+    os.environ['ENGINE'] = 'MySQLJDBC'
     setup()
     mock_register_secret.assert_called_with(
         'root', 'example', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy'
@@ -39,4 +42,26 @@ def test_setup_postgres(mocker) -> None:
         'postgres',
         'example',
         {'JAR_PATH': '/usr/lib/jvm/postgresql-java-client.jar'},
+    )
+
+def test_setup_postgres_no_jdbc(mocker) -> None:
+    mock_register_secret = mocker.patch('local_data_api.settings.register_secret')
+    mock_register_resource = mocker.patch('local_data_api.settings.register_resource')
+    import os
+
+    os.environ['ENGINE'] = 'PostgresSQL'
+    setup()
+    mock_register_secret.assert_called_with(
+        'postgres',
+        'example',
+        'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
+    )
+    mock_register_resource.assert_called_with(
+        'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
+        'PostgresSQL',
+        '127.0.0.1',
+        5432,
+        'postgres',
+        'example',
+        {}
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,6 +44,7 @@ def test_setup_postgres(mocker) -> None:
         {'JAR_PATH': '/usr/lib/jvm/postgresql-java-client.jar'},
     )
 
+
 def test_setup_postgres_no_jdbc(mocker) -> None:
     mock_register_secret = mocker.patch('local_data_api.settings.register_secret')
     mock_register_resource = mocker.patch('local_data_api.settings.register_resource')
@@ -63,5 +64,5 @@ def test_setup_postgres_no_jdbc(mocker) -> None:
         5432,
         'postgres',
         'example',
-        {}
+        {},
     )


### PR DESCRIPTION
Hello! 
I have completed the support for PostgreSQL without using JDBC (just a basic configuration).
In my case, it solves the issue https://github.com/koxudaxi/local-data-api/issues/50.

I have updated the settings part in which the appropriate database engine is selected.

For further works it would be great to add more details to the `ColumnMetadata` infos