### PR TITLE
fix invalid autocommit control

### DIFF
--- a/local_data_api/resources/jdbc/__init__.py
+++ b/local_data_api/resources/jdbc/__init__.py
@@ -51,7 +51,6 @@ class JDBC(Resource, ABC):
     def __init__(self, connection: Connection, transaction_id: Optional[str] = None):
         if transaction_id:
             attach_thread_to_jvm()
-        self.autocommit: bool = True
         super().__init__(connection, transaction_id)
 
     def create_column_metadata_set(
@@ -78,9 +77,8 @@ class JDBC(Resource, ABC):
             for i in range(1, meta.getColumnCount() + 1)
         ]
 
-    def autocommit_off(self, cursor: jaydebeapi.Cursor) -> None:
+    def autocommit_off(self) -> None:  # pragma: no cover
         self.connection.jconn.setAutoCommit(False)
-        self.autocommit = False
 
     @staticmethod
     @abstractmethod
@@ -102,9 +100,6 @@ class JDBC(Resource, ABC):
             cursor: Optional[jaydebeapi.Cursor] = None
             try:
                 cursor = self.connection.cursor()
-
-                if self.autocommit:
-                    self.autocommit_off(cursor)
 
                 self.reset_generated_id(cursor)
                 if params:

--- a/local_data_api/resources/mysql.py
+++ b/local_data_api/resources/mysql.py
@@ -41,6 +41,10 @@ def create_column_metadata(
 
 @register_resource_type
 class MySQL(Resource):
+    def autocommit_off(self) -> None:  # pragma: no cover
+        # default is off
+        pass
+
     def create_column_metadata_set(self, cursor: Cursor) -> List[ColumnMetadata]:
         return [create_column_metadata(f) for f in getattr(cursor, '_result').fields]
 

--- a/local_data_api/resources/postgres.py
+++ b/local_data_api/resources/postgres.py
@@ -34,6 +34,10 @@ def create_column_metadata(field_descriptor_packet: Column) -> ColumnMetadata:
 
 @register_resource_type
 class PostgresSQL(Resource):
+    def autocommit_off(self) -> None:  # pragma: no cover
+        # default is off
+        pass
+
     def create_column_metadata_set(
         self, cursor: Cursor
     ) -> List[ColumnMetadata]:  # pragma: no cover

--- a/local_data_api/resources/resource.py
+++ b/local_data_api/resources/resource.py
@@ -356,10 +356,15 @@ class Resource(ABC):
         if self.transaction_id in CONNECTION_POOL:
             delete_connection(self.transaction_id)
 
+    @abstractmethod
+    def autocommit_off(self) -> None:
+        raise NotImplementedError
+
     def begin(self) -> str:
         transaction_id = self.create_transaction_id()
         self._transaction_id = transaction_id
         set_connection(transaction_id, self.connection)
+        self.autocommit_off()
         return transaction_id
 
     def commit(self) -> None:

--- a/local_data_api/resources/sqlite.py
+++ b/local_data_api/resources/sqlite.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @register_resource_type
 class SQLite(Resource):
+    def autocommit_off(self) -> None:
+        # default is off
+        pass
+
     def create_column_metadata_set(self, cursor: Cursor) -> List[ColumnMetadata]:
         raise NotImplementedError
 

--- a/tests/test_resource/test_resource.py
+++ b/tests/test_resource/test_resource.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 
 
 class DummyResource(Resource):
+    def autocommit_off(self) -> None:
+        pass
+
     def create_column_metadata_set(self, cursor: Cursor) -> List[ColumnMetadata]:
         pass
 
@@ -279,9 +282,11 @@ def test_begin(clear, mocker):
     set_connection_mock = mocker.patch(
         'local_data_api.resources.resource.set_connection'
     )
+    dummy.autocommit_off = mocker.Mock()
     result = dummy.begin()
     assert result == 'abc'
     set_connection_mock.assert_called_once_with('abc', connection_mock)
+    dummy.autocommit_off.assert_called_once()
 
 
 def test_close(clear, mocker):


### PR DESCRIPTION
This PR fixes a bug when the server does `commit` without any `query` immediately after `begin`.


## Related issues
https://github.com/koxudaxi/local-data-api/issues/41