### PR TITLE
Fix incorrect autocommit

### DIFF
--- a/local_data_api/main.py
+++ b/local_data_api/main.py
@@ -85,6 +85,9 @@ def execute_statement(request: ExecuteStatementRequests) -> ExecuteStatementResp
             request.database,
         )
 
+        if not resource.transaction_id:
+            resource.autocommit_off()
+
         if request.parameters:
             parameters: Optional[Dict[str, Any]] = {
                 parameter.name: parameter.valid_value


### PR DESCRIPTION
This PR fixes incorrect auto-commit when running execute-statement without `transactionId`.

## Related Issue
https://github.com/koxudaxi/local-data-api/issues/38